### PR TITLE
Custom domain: serve from hs.yongseongkimm.com

### DIFF
--- a/src/pages/wedding/index.tsx
+++ b/src/pages/wedding/index.tsx
@@ -56,14 +56,14 @@ export default function WeddingPage(): JSX.Element {
         />
         <meta
           property="og:image"
-          content="https://yongseongkim.github.io/img/wedding/cover.jpg"
+          content="https://hs.yongseongkimm.com/img/wedding/cover.jpg"
         />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="1600" />
         <meta property="og:image:alt" content="조현수 · 김용성" />
         <meta
           property="og:url"
-          content="https://yongseongkim.github.io/wedding/"
+          content="https://hs.yongseongkimm.com/wedding/"
         />
         <meta property="og:locale" content="ko_KR" />
 
@@ -75,7 +75,7 @@ export default function WeddingPage(): JSX.Element {
         />
         <meta
           name="twitter:image"
-          content="https://yongseongkim.github.io/img/wedding/cover.jpg"
+          content="https://hs.yongseongkimm.com/img/wedding/cover.jpg"
         />
 
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+hs.yongseongkimm.com


### PR DESCRIPTION
## Summary
- Add `static/CNAME` (`hs.yongseongkimm.com`) so GitHub Pages binds the custom domain.
- Update OG image, og:url, twitter:image to the new host — Kakao/Facebook will re-fetch since the URL changed (resolves stale-cache issue from the previous deploy).

## After merge
1. Repo Settings → Pages → Custom domain: `hs.yongseongkimm.com` → Save.
2. Wait ~10–30 min for Let's Encrypt cert.
3. Enable "Enforce HTTPS".

## Test plan
- [ ] DNS: `dig +short hs.yongseongkimm.com @1.1.1.1` returns GitHub Pages IPs (185.199.108–111.153)
- [ ] After step 1 above, `https://hs.yongseongkimm.com/wedding/` serves the wedding page
- [ ] Kakao preview tool (developers.kakao.com/tool/clear/og) → paste new URL → fresh preview with current cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)